### PR TITLE
Run apt-get-update to prevent stale index

### DIFF
--- a/.github/workflows/create-docker-hub-image-java.yml
+++ b/.github/workflows/create-docker-hub-image-java.yml
@@ -58,6 +58,7 @@ jobs:
       - name: Push to Docker Hub
         working-directory: ./project
         run: |
+          sudo apt-get update
           sudo apt-get install -y qemu qemu-user-static
           ./gradlew \
           -PAWS_MAVEN_ACCESS_KEY_ID=${{ secrets.AWS_MAVEN_ACCESS_KEY_ID }} \


### PR DESCRIPTION
I was running into a 404 when trying to install a new package. According to [this](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-ubuntu-runners) we should run `sudo apt-get update` to prevent any staleness 
```
Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  qemu qemu-user-static
0 upgraded, 2 newly installed, 0 to remove and 34 not upgraded.
Need to get 13.0 MB of archives.
After this operation, 130 MB of additional disk space will be used.
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [142 B]
Ign:2 http://azure.archive.ubuntu.com/ubuntu jammy-updates/universe amd64 qemu amd64 1:6.2+dfsg-2ubuntu6.19
Ign:3 http://azure.archive.ubuntu.com/ubuntu jammy-updates/universe amd64 qemu-user-static amd64 1:6.2+dfsg-2ubuntu6.19
Ign:2 http://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 qemu amd64 1:6.2+dfsg-2ubuntu6.19
Err:2 http://security.ubuntu.com/ubuntu jammy-updates/universe amd64 qemu amd64 1:6.2+dfsg-2ubuntu6.19
  404  Not Found [IP: 52.252.75.106 80]
Ign:3 http://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 qemu-user-static amd64 1:6.2+dfsg-2ubuntu6.19
Err:3 http://security.ubuntu.com/ubuntu jammy-updates/universe amd64 qemu-user-static amd64 1:6.2+dfsg-2ubuntu6.19
  404  Not Found [IP: 52.252.75.106 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/universe/q/qemu/qemu_6.2%2bdfsg-2ubuntu6.19_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/universe/q/qemu/qemu-user-static_6.2%2bdfsg-2ubuntu6.19_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```