### PR TITLE
VST-702 code coverage in check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,3 +41,40 @@ jobs:
           -PTW_MAVEN_ACCESS_KEY_ID=${{ secrets.AWS_MAVEN_ACCESS_KEY_ID }}
           -PTW_MAVEN_ACCESS_SECRET_KEY=${{ secrets.AWS_MAVEN_ACCESS_SECRET_KEY }}
           check
+
+      - name: Gradle test coverage
+        working-directory: ./project
+        run: ./gradlew testCoverage
+
+      - run: ls -l ./
+        if: always()
+      - run: ls -l ./gradle-scripts
+        if: always()
+      - run: ls -l ./project/build/reports
+        if: always()
+      - run: ls -l ./project/build/reports/jacoco
+        if: always()
+      - run: ls -l ./project/build/reports/jacoco/testCoverage
+        if: always()
+
+      - name: Generate Coverage Report
+        if: always()
+        id: jacoco_reporter
+        uses: PavanMudigonda/jacoco-reporter@v5.0
+        with:
+          coverage_results_path: ./project/build/reports/jacoco/testCoverage/testCoverage.xml
+          coverage_report_name: Coverage
+          coverage_report_title: JaCoCo
+          skip_check_run: false
+          fail_below_threshold: false
+          publish_only_summary: true
+
+      - name: Add Coverage report to workflow run summary
+        if: always()
+        run: |
+          echo "| Outcome | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "| --- | --- |" >> $GITHUB_STEP_SUMMARY
+          echo "| Code Coverage % | ${{ steps.jacoco_reporter.outputs.coverage_percentage }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| :heavy_check_mark: Number of Lines Covered | ${{ steps.jacoco_reporter.outputs.covered_lines }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| :x: Number of Lines Missed | ${{ steps.jacoco_reporter.outputs.missed_lines }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Total Number of Lines | ${{ steps.jacoco_reporter.outputs.total_lines }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,20 +42,9 @@ jobs:
           -PTW_MAVEN_ACCESS_SECRET_KEY=${{ secrets.AWS_MAVEN_ACCESS_SECRET_KEY }}
           check
 
-      - name: Gradle test coverage
+      - name: Gradle Test Coverage
         working-directory: ./project
         run: ./gradlew testCoverage
-
-      - run: ls -l ./
-        if: always()
-      - run: ls -l ./gradle-scripts
-        if: always()
-      - run: ls -l ./project/build/reports
-        if: always()
-      - run: ls -l ./project/build/reports/jacoco
-        if: always()
-      - run: ls -l ./project/build/reports/jacoco/testCoverage
-        if: always()
 
       - name: Generate Coverage Report
         if: always()


### PR DESCRIPTION
The overall goal is to have test coverage reports for VAST services.
To achieve that, I've added a separate workflow for a coverage report in a previous PR - https://github.com/tastyworks/boulangerie-shared-github-workflows/blob/main/.github/workflows/code-coverage-report.yml
 
After a chat with Kevin, we decided to add a code coverage step to a check.yml, so `gradle test` won't be executed twice.

In this PR  I'm moving the steps to check.yml, there will be one more needed to remove code-coverage-report.yml after all services are updated.

I've updated fifty-percent-pop-server-java as a first one, you can see the results here:

https://github.com/tastyworks/fifty-percent-pop-server-java/actions/runs/13112988150