### PR TITLE
VST-702 add Checkout dynamodb-test-lib step to action.yml

### DIFF
--- a/.github/common-setup/action.yml
+++ b/.github/common-setup/action.yml
@@ -23,7 +23,10 @@ inputs:
   DOCKER_PASSWORD:
     description: Docker password
     required: false
-
+  WITH_DYNAMODB:
+    description: dynamodb-test-lib-java
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -67,5 +70,10 @@ runs:
       if: ${{ inputs.WITH_DOCKER == 'true' }}
       uses: docker/setup-qemu-action@v3
 
-
-
+    - name: Checkout dynamodb-test-lib
+      if: ${{ inputs.WITH_DYNAMODB == true }}
+      uses: actions/checkout@v4
+      with:
+        repository: tastyworks/tastyworks-dynamodb-test-lib-java
+        token: ${{ secrets.GH_ACCESS_TOKEN }}
+        path: tastyworks-dynamodb-test-lib-java

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: boolean
         default: false
+      WITH_DYNAMODB:
+        description: dynamodb-test-lib-java
+        required: false
+        type: boolean
+        default: false
     secrets:
       GH_ACCESS_TOKEN:
         required: true


### PR DESCRIPTION
we want to use a shared check workflow for VAST services. some services need dynamodb to run the check, for example https://github.com/tastyworks/market-metrics-server-java/blob/8e81e2f920fe85e71526b67b33b4b0dec566d485/.github/workflows/check_and_deploy.yml#L29 
so I want to add it to the shared check workflow