### PR TITLE
Upgrade gradle/actions/setup-gradle to v4

### DIFF
--- a/.github/common-setup/action.yml
+++ b/.github/common-setup/action.yml
@@ -69,7 +69,7 @@ runs:
         java-version: ${{ env.JAVA_VERSION }}
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v3
+      uses: gradle/actions/setup-gradle@v4
 
     - name: Login to Docker Hub
       if: ${{ inputs.WITH_DOCKER == 'true' }}


### PR DESCRIPTION
The java teams started seeing github actions taking a lot longer.

We noticed connect timeout issues like this one:
![image](https://github.com/user-attachments/assets/0a20b175-44e7-4969-8108-52dfc0e00d16)

Other people noticed similar things:
https://github.com/orgs/community/discussions/160793

Some people in that thread report that their issues were resolved after upgrading third party actions.

As such, this PR upgrades setup-gradle to the latest version to attempt to resolve these connect timeouts causing actions to take forever.